### PR TITLE
Trigger a re-filter when an area tag is clicked

### DIFF
--- a/try/index.html
+++ b/try/index.html
@@ -187,6 +187,7 @@
             padding: 4px 8px;
             border-radius: 4px;
             font-size: 14px;
+            cursor: pointer;
         }
 
         .globe-icon {
@@ -608,7 +609,7 @@
                     </div>
                     <div class="research-areas">
                         ${faculty.areas.map(area => `
-                            <span class="area-tag">${area}</span>
+                            <span class="area-tag" onclick="javascript:filterFaculty('${area}')">${area}</span>
                         `).join('')}
                     </div>
                 `;


### PR DESCRIPTION
A nice next feature would be to update the page history [using `history.pushState`](https://developer.mozilla.org/en-US/docs/Web/API/History_API/Working_with_the_History_API) — because, right now, if you click _back_ you leave the site altogether, which is jarring — but I'll leave that for another day. :-)